### PR TITLE
Path fix for case-sensitive OS 

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -141,7 +141,7 @@ async function createImage({ filepath, basename, scale }, resizedImages, appReso
     const width = await getImageWidth(filepath, scale);
 
     for (const resizedImage of resizedImages) {
-        await resizeImage(filepath, path.join(appResourcesDir, platform, resizedImage.path), width * resizedImage.scale);
+        await resizeImage(filepath, path.join(appResourcesDir, platform === 'ios' ? 'iOS' : 'Android', resizedImage.path), width * resizedImage.scale);
     }
 }
 
@@ -189,7 +189,7 @@ function getPlatformRelativeResourcesDirectoryPath(platform) {
 }
 
 function getPlatformResourcesDirectoryPath(appResourcesDir, platform) {
-    return path.join(appResourcesDir, platform, getPlatformRelativeResourcesDirectoryPath(platform));
+    return path.join(appResourcesDir, platform === 'ios' ? 'iOS' : 'Android', getPlatformRelativeResourcesDirectoryPath(platform));
 }
 
 module.exports = {


### PR DESCRIPTION
Fix for the resource path on case sensitive OS platforms like MacOS (my partition is case-sensitive) that expects case-sensitive file page and it fails for App_Resources/ios (needs to be App_Resources/iOS) and App_Resources/android (needs to be App_Resources/Android). Issue #6 