### PR TITLE
Fix Build crashes when 'platforms' folder doesn't exist on 'tns run' and update dependencies

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -6,8 +6,12 @@ const stat = promisify(fs.stat);
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
 
+function getPlatformCacheFolderPath(platformsDir) {
+    return path.join(platformsDir, 'tempPlugin/nativescript-images-generator-hook');
+}
+
 function getPlatformCacheFilePath(platformsDir, platform) {
-    return path.join(platformsDir, platform, '.nsimagesgenerator.json');
+    return path.join(getPlatformCacheFolderPath(platformsDir), `${platform}.nsimagesgenerator.json`);
 }
 
 async function getPlatformCache(platformsDir, platform) {
@@ -67,6 +71,7 @@ async function getPlatformCache(platformsDir, platform) {
 
 async function savePlatformCache(cache, platformsDir, platform) {
     const platformCacheFilePath = getPlatformCacheFilePath(platformsDir, platform);
+    const platformCacheFolderPath = getPlatformCacheFolderPath(platformsDir);
 
     // Sanitize cache before saving
     const filteredCache = {
@@ -78,8 +83,12 @@ async function savePlatformCache(cache, platformsDir, platform) {
         })),
         output: cache.output,
     };
-
+    fs.mkdir(platformCacheFolderPath, { recursive: true }, (error) => { 
+        if (error) throw new Error(`Unable to create cache file folder. (${error.message})`);
+    });
     try {
+        // Creates the folder if does not exist
+        
         await writeFile(platformCacheFilePath, JSON.stringify(filteredCache), 'utf8');
     } catch (error) {
         throw new Error(`Unable to save images generator cache file. (${error.message})`);

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -83,7 +83,7 @@ async function savePlatformCache(cache, platformsDir, platform) {
         })),
         output: cache.output,
     };
-    fs.mkdir(platformCacheFolderPath, { recursive: true }, (error) => { 
+    fs.mkdirSync(platformCacheFolderPath, { recursive: true }, (error) => { 
         if (error) throw new Error(`Unable to create cache file folder. (${error.message})`);
     });
     try {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "homepage": "https://github.com/Creatiwity/nativescript-images-generator-hook#readme",
   "nativescript": {
     "platforms": {
-      "android": "6.0.0",
-      "ios": "6.0.1"
+      "android": "7.0.1",
+      "ios": "7.2.0"
     },
     "hooks": [
       {
@@ -32,13 +32,7 @@
         "script": "lib/before-prepare.js",
         "inject": true
       }
-    ],
-    "tns-ios": {
-      "version": "6.0.1"
-    },
-    "tns-android": {
-      "version": "6.0.0"
-    }
+    ]
   },
   "scripts": {
     "postinstall": "node postinstall.js",

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,1 +1,1 @@
-require('nativescript-hook')(__dirname).postinstall(__dirname);
+require('@nativescript/hook')(__dirname).postinstall(__dirname);

--- a/preuninstall.js
+++ b/preuninstall.js
@@ -1,1 +1,1 @@
-require('nativescript-hook')(__dirname).preuninstall(__dirname);
+require('@nativescript/hook')(__dirname).preuninstall(__dirname);


### PR DESCRIPTION
This solves the issue(#5) when the project doesn't have a platform added. To solve this problem the plugin uses its own folder instead of the Android or iOS folder.

I also updated the dependency nativescript-hook to the new repository at @nativescript/hook.